### PR TITLE
Fix to prevent ascii characters from being replace with codepoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,12 @@ module.exports = function (){
 			file.contents = Buffer.from( file.contents.toString().replace( rg, function(input, whitespace, p2){
 				var content = '';
 				for (var i = 0; i < p2.length; i++) {
-					content += "\\" + p2.codePointAt(i).toString(16);
+					var codePoint = p2.codePointAt(i);
+					if (codePoint > 127) {
+						content += "\\" + p2.codePointAt(i).toString(16);
+					} else {
+						content += p2.charAt(i);
+					}
 				}
 
 				return "content:" + whitespace + "\"" + content + "\"";

--- a/test/scss/test-mixed-unicode.scss
+++ b/test/scss/test-mixed-unicode.scss
@@ -1,0 +1,40 @@
+$fa-var-bicycle: "\f206";
+$fa-var-binoculars: "\f1e5";
+$fa-var-birthday-cake: "\f1fd";
+$my-string: "myString";
+
+.var {
+    &::before {
+        content: $fa-var-bicycle;
+    }
+}
+
+.direct {
+    &::before {
+        content: "\f206";
+    }
+}
+
+.var-multichar {
+    &::before {
+        content: $fa-var-bicycle + $fa-var-binoculars + $fa-var-birthday-cake;
+    }
+}
+
+.direct-multichar {
+    &::before {
+        content: "\f206\f1e5\f1fd";
+    }
+}
+
+.var-string {
+    &::before {
+        content: $my-string;
+    }
+}
+
+.direct-string {
+    &::before {
+        content: "myString";
+    }
+}

--- a/test/test-mixed-unicode.css
+++ b/test/test-mixed-unicode.css
@@ -1,0 +1,18 @@
+@charset "UTF-8";
+.var::before {
+  content: "\f206"; }
+
+.direct::before {
+  content: "\f206"; }
+
+.var-multichar::before {
+  content: "\f206\f1e5\f1fd"; }
+
+.direct-multichar::before {
+  content: "\f206\f1e5\f1fd"; }
+
+.var-string::before {
+  content: "myString"; }
+
+.direct-string::before {
+  content: "myString"; }

--- a/test/test.js
+++ b/test/test.js
@@ -70,4 +70,35 @@ describe('gulp-sass-unicode', function() {
 
     });
 
+    it('Compile Mixed Unicode and Escape Sequences.', function(done) {
+
+        var sassStream = sass();
+
+        sassStream.on('data', function(sassData) {
+
+            var unicodeStream = sass_unicode();
+
+            unicodeStream.on('data', function(unicodeData) {
+                assert.equal(unicodeData.contents.toString(), fs.readFileSync('test/test-mixed-unicode.css').toString());
+            });
+
+            unicodeStream.on('end', done);
+
+            unicodeStream.write(new Vinyl({
+                contents: new Buffer.from(sassData.contents)
+            }));
+
+            unicodeStream.end();
+
+        });
+
+        sassStream.write(new Vinyl({
+            path: 'test/scss/test-mixed-unicode.scss',
+            contents: new Buffer.from(fs.readFileSync('test/scss/test-mixed-unicode.scss'))
+        }));
+
+        sassStream.end();
+
+    });
+
 });


### PR DESCRIPTION
This should prevent code point escaping for characters that do not need it, as well as preventing attempts to re-escape escape sequences by only escaping characters with code points higher than 127. This issues is partially caused by SASS treating escape sequences in variables differently than ones directly entered into content. I've added a new test to check various combinations of variables and inline content.